### PR TITLE
Change references to shinygadgets to miniUI

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -55,11 +55,11 @@ Let's start by playing around with a couple of the example addins provided by th
 ```{r, eval=FALSE}
 devtools::install_github("rstudio/htmltools")
 devtools::install_github("rstudio/shiny")
-devtools::install_github("rstudio/shinygadgets")
+devtools::install_github("rstudio/miniUI")
 devtools::install_github("rstudio/addinexamples")
 ```
 
-Note that for the time being the **addinexamples** package requires development versions of the **htmltools**, **shiny**, and **shinygadgets** packages, so please be sure to install those as well!
+Note that for the time being the **addinexamples** package requires development versions of the **htmltools**, **shiny**, and **miniUI** packages, so please be sure to install those as well!
 
 ### Running Addins
 
@@ -181,21 +181,24 @@ Shiny gadgets are Shiny applications which can be registered and run as addins. 
 
 Shiny Gadgets are similar to regular Shiny applications. You will need to develop a `ui` and a `server` for your gadget, and then use the `runGadget()` function to launch your gadget.
 
-Shiny Gadgets require development versions of the **htmltools**, **shiny**, and **shinygadgets** packages so you should be sure to install them before developing your addin. You can do this as follows:
+Shiny Gadgets require development versions of the **htmltools**, **shiny**, and **miniUI** packages so you should be sure to install them before developing your addin. You can do this as follows:
 
 ```{r, eval=FALSE}
-devtools::install_github(c("rstudio/htmltools", "rstudio/shiny", "rstudio/shinygadgets"))
+devtools::install_github(c("rstudio/htmltools", "rstudio/shiny", "rstudio/miniUI"))
 ```
 
 
 ### Gadget UI
 
-The UI for a Shiny Gadget can be generated using the `gadgetPage()` function. Typically, the UI definition of a Shiny Gadget will have the following form:
+The UI for a Shiny Gadget can be generated using functions from the miniUI package. Typically, the UI definition of a Shiny Gadget will have the following form:
 
 ```{r, eval=FALSE}
-ui <- gadgetPage(
-  titlebar("My Gadget"),
-  contentPanel(
+library(shiny)
+library(miniUI)
+
+ui <- miniPage(
+  miniTitleBar("My Gadget"),
+  miniContentPanel(
     ## Your UI items go here.
   )
 )
@@ -243,7 +246,7 @@ Let's combine the above components into a simple 'Hello Shiny' gadget. We'll cre
 
 ```{r, eval=FALSE}
 library(shiny)
-library(shinygadgets)
+library(miniUI)
 
 # We'll wrap our Shiny Gadget in an addin.
 # Let's call it 'clockAddin()'.
@@ -251,9 +254,9 @@ clockAddin <- function() {
   
   # Our ui will be a simple gadget page, which
   # simply displays the time in a 'UI' output.
-  ui <- gadgetPage(
-    titlebar("Clock"),
-    contentPanel(
+  ui <- miniPage(
+    miniTitleBar("Clock"),
+    miniContentPanel(
       uiOutput("time")
     )
   )
@@ -317,17 +320,17 @@ Congratulations! You're now ready to write your own Shiny gadgets.
 
 ### Installation
 
-Currently, running Shiny Gadgets requires that you install development versions of the [**htmltools**](https://github.com/rstudio/htmltools), [**shiny**](https://github.com/rstudio/shiny) and [**shinygadgets**](https://github.com/rstudio/shinygadgets) packages. Therefore, if you are distributing a Shiny Gadget based addin then users of your addin will also need to install the following packages in addition to the one that hosts your addin:
+Currently, running Shiny Gadgets requires that you install development versions of the [**htmltools**](https://github.com/rstudio/htmltools), [**shiny**](https://github.com/rstudio/shiny), and [**miniUI**](https://github.com/rstudio/miniUI) packages. Therefore, if you are distributing a Shiny Gadget based addin then users of your addin will also need to install the following packages in addition to the one that hosts your addin:
 
 ```{r, eval=FALSE}
-devtools::install_github(c("rstudio/htmltools", "rstudio/shiny", "rstudio/shinygadgets"))
+devtools::install_github(c("rstudio/htmltools", "rstudio/shiny", "rstudio/miniUI"))
 ```
 
-Updated versions of the **htmltools**, **shiny**, and **shinygadgets** packages will be submited to CRAN soon, after which you'll need only declare that your addin package depends on these updated versions.
+Updated versions of these packages will be submitted to CRAN soon, after which you'll need only declare that your addin package depends on these updated versions.
 
 ### More Examples
 
-The **addinexaples** package contains several additional examples of Shiny Gadget based addins:
+The **addinexamples** package contains several additional examples of Shiny Gadget based addins:
 
 - [Find and Replace](https://github.com/rstudio/addinexamples/blob/master/R/findAndReplaceAddin.R) --- Find and replace words in a document.
 

--- a/index.html
+++ b/index.html
@@ -193,19 +193,19 @@ blockquote {
 RStudio Addins
 </div>
 <div id="release-note">
-<p><strong>IMPORTANT NOTE:</strong> Support for addins is available only within the <a href="https://www.rstudio.com/products/rstudio/download/preview/">Preview Release</a> of RStudio (v0.99.825 or later). If you want to try out addins please be sure to download the preview release.</p>
+<strong>IMPORTANT NOTE:</strong> Support for addins is available only within the <a href="https://www.rstudio.com/products/rstudio/download/preview/">Preview Release</a> of RStudio (v0.99.825 or later). If you want to try out addins please be sure to download the preview release.
 </div>
 <p>RStudio addins provide a mechanism for executing R functions interactively from within the RStudio IDE—either through keyboard shortcuts, or through the <em>Addins</em> menu.</p>
 <p>An addin can be as simple as a function that inserts a commonly used snippet of text, and as complex as a Shiny application that accepts input from the user, and later mutates a document open in RStudio. The sky is limit!</p>
 <p>Here are two examples of addins in action (click on the thumbnail to see a brief demonstration):</p>
 <div class="row">
 <div class="col-xs-6">
-<h4 id="subset-a-dataset">Subset a dataset</h4>
-<p><a class="thumbnail" href="demo/demo-subset.gif" data-lightbox="examples" data-title="Subset a dataset"> <img class="example-image" src="demo/demo-subset.png"/> </a></p>
+<h4>Subset a dataset</h4>
+<a class="thumbnail" href="demo/demo-subset.gif" data-lightbox="examples" data-title="Subset a dataset"> <img class="example-image" src="demo/demo-subset.png"/> </a>
 </div>
 <div class="col-xs-6">
-<h4 id="reformat-r-code">Reformat R code</h4>
-<p><a class="thumbnail" href="demo/demo-reformat.gif" data-lightbox="examples" data-title="Reformat R code"> <img class="example-image" src="demo/demo-reformat.png"/> </a></p>
+<h4>Reformat R code</h4>
+<a class="thumbnail" href="demo/demo-reformat.gif" data-lightbox="examples" data-title="Reformat R code"> <img class="example-image" src="demo/demo-reformat.png"/> </a>
 </div>
 </div>
 </div>
@@ -218,9 +218,9 @@ RStudio Addins
 <p>Let’s start by playing around with a couple of the example addins provided by the <a href="https://github.com/rstudio/addinexamples">addinexamples</a> package. Within RStudio, install this package (plus its requisite dependencies) with:</p>
 <pre class="r"><code>devtools::install_github(&quot;rstudio/htmltools&quot;)
 devtools::install_github(&quot;rstudio/shiny&quot;)
-devtools::install_github(&quot;rstudio/shinygadgets&quot;)
+devtools::install_github(&quot;rstudio/miniUI&quot;)
 devtools::install_github(&quot;rstudio/addinexamples&quot;)</code></pre>
-<p>Note that for the time being the <strong>addinexamples</strong> package requires development versions of the <strong>htmltools</strong>, <strong>shiny</strong>, and <strong>shinygadgets</strong> packages, so please be sure to install those as well!</p>
+<p>Note that for the time being the <strong>addinexamples</strong> package requires development versions of the <strong>htmltools</strong>, <strong>shiny</strong>, and <strong>miniUI</strong> packages, so please be sure to install those as well!</p>
 </div>
 <div id="running-addins" class="section level3">
 <h3>Running Addins</h3>
@@ -330,14 +330,14 @@ Interactive: false</code></pre>
 <h2>Shiny Gadgets</h2>
 <p>Shiny gadgets are Shiny applications which can be registered and run as addins. Typically, a Shiny Gadget provides a mechanism for interactively generating code, or modifying a document, but within this realm the possibilities are endless. Let’s go through how you might create a Shiny gadget.</p>
 <p>Shiny Gadgets are similar to regular Shiny applications. You will need to develop a <code>ui</code> and a <code>server</code> for your gadget, and then use the <code>runGadget()</code> function to launch your gadget.</p>
-<p>Shiny Gadgets require development versions of the <strong>htmltools</strong>, <strong>shiny</strong>, and <strong>shinygadgets</strong> packages so you should be sure to install them before developing your addin. You can do this as follows:</p>
-<pre class="r"><code>devtools::install_github(c(&quot;rstudio/htmltools&quot;, &quot;rstudio/shiny&quot;, &quot;rstudio/shinygadgets&quot;))</code></pre>
+<p>Shiny Gadgets require development versions of the <strong>htmltools</strong>, <strong>shiny</strong>, and <strong>miniUI</strong> packages so you should be sure to install them before developing your addin. You can do this as follows:</p>
+<pre class="r"><code>devtools::install_github(c(&quot;rstudio/htmltools&quot;, &quot;rstudio/shiny&quot;, &quot;rstudio/miniUI&quot;))</code></pre>
 <div id="gadget-ui" class="section level3">
 <h3>Gadget UI</h3>
-<p>The UI for a Shiny Gadget can be generated using the <code>gadgetPage()</code> function. Typically, the UI definition of a Shiny Gadget will have the following form:</p>
-<pre class="r"><code>ui &lt;- gadgetPage(
-  titlebar(&quot;My Gadget&quot;),
-  contentPanel(
+<p>The UI for a Shiny Gadget can be generated using functions from the miniUI package. Typically, the UI definition of a Shiny Gadget will have the following form:</p>
+<pre class="r"><code>ui &lt;- miniPage(
+  miniTitleBar(&quot;My Gadget&quot;),
+  miniContentPanel(
     ## Your UI items go here.
   )
 )</code></pre>
@@ -377,7 +377,7 @@ Interactive: false</code></pre>
 <h3>Putting It Together</h3>
 <p>Let’s combine the above components into a simple ‘Hello Shiny’ gadget. We’ll create a clock that updates its display every second. Try running the following code in RStudio – you should see a clock displayed in the viewer pane. When you click <code>Done</code>, the current time will be inserted at the cursor position.</p>
 <pre class="r"><code>library(shiny)
-library(shinygadgets)
+library(miniUI)
 
 # We&#39;ll wrap our Shiny Gadget in an addin.
 # Let&#39;s call it &#39;clockAddin()&#39;.
@@ -385,9 +385,9 @@ clockAddin &lt;- function() {
   
   # Our ui will be a simple gadget page, which
   # simply displays the time in a &#39;UI&#39; output.
-  ui &lt;- gadgetPage(
-    titlebar(&quot;Clock&quot;),
-    contentPanel(
+  ui &lt;- miniPage(
+    miniTitleBar(&quot;Clock&quot;),
+    miniContentPanel(
       uiOutput(&quot;time&quot;)
     )
   )
@@ -448,13 +448,13 @@ clockAddin()
 </div>
 <div id="installation-1" class="section level3">
 <h3>Installation</h3>
-<p>Currently, running Shiny Gadgets requires that you install development versions of the <a href="https://github.com/rstudio/htmltools"><strong>htmltools</strong></a>, <a href="https://github.com/rstudio/shiny"><strong>shiny</strong></a> and <a href="https://github.com/rstudio/shinygadgets"><strong>shinygadgets</strong></a> packages. Therefore, if you are distributing a Shiny Gadget based addin then users of your addin will also need to install the following packages in addition to the one that hosts your addin:</p>
-<pre class="r"><code>devtools::install_github(c(&quot;rstudio/htmltools&quot;, &quot;rstudio/shiny&quot;, &quot;rstudio/shinygadgets&quot;))</code></pre>
-<p>Updated versions of the <strong>htmltools</strong>, <strong>shiny</strong>, and <strong>shinygadgets</strong> packages will be submited to CRAN soon, after which you’ll need only declare that your addin package depends on these updated versions.</p>
+<p>Currently, running Shiny Gadgets requires that you install development versions of the <a href="https://github.com/rstudio/htmltools"><strong>htmltools</strong></a>, <a href="https://github.com/rstudio/shiny"><strong>shiny</strong></a>, and <a href="https://github.com/rstudio/miniUI"><strong>miniUI</strong></a> packages. Therefore, if you are distributing a Shiny Gadget based addin then users of your addin will also need to install the following packages in addition to the one that hosts your addin:</p>
+<pre class="r"><code>devtools::install_github(c(&quot;rstudio/htmltools&quot;, &quot;rstudio/shiny&quot;, &quot;rstudio/miniUI&quot;))</code></pre>
+<p>Updated versions of these packages will be submitted to CRAN soon, after which you’ll need only declare that your addin package depends on these updated versions.</p>
 </div>
 <div id="more-examples" class="section level3">
 <h3>More Examples</h3>
-<p>The <strong>addinexaples</strong> package contains several additional examples of Shiny Gadget based addins:</p>
+<p>The <strong>addinexamples</strong> package contains several additional examples of Shiny Gadget based addins:</p>
 <ul>
 <li><p><a href="https://github.com/rstudio/addinexamples/blob/master/R/findAndReplaceAddin.R">Find and Replace</a> — Find and replace words in a document.</p></li>
 <li><p><a href="https://github.com/rstudio/addinexamples/blob/master/R/reformatAddin.R">Reformat R Code</a> — Reformat R code using <code>formatR::tidy_source()</code>.</p></li>


### PR DESCRIPTION
After talking to JJ today, I did some refactoring that took all the non-UI stuff out of shinygadgets. All that's left is a "compact" UI framework that isn't specific to gadgets (i.e. can be used in normal Shiny apps). We decided to rename this package to "miniUI".
